### PR TITLE
Add CORS setting to draw S3 image on canvas

### DIFF
--- a/canvashare/easel/main.js
+++ b/canvashare/easel/main.js
@@ -147,8 +147,10 @@ function loadDrawing() {
 
 // Set up drawing space with passed drawing source and title
 function assembleEasel(drawingSrc, title) {
-  // Create new image as initial drawing
+  /* Create new image as initial starting drawing and set CORS requests as
+  anonymous (no credentials required to display image) */
   initialDrawing = new Image();
+  initialDrawing.crossOrigin = 'Anonymous';
 
   // Set initial drawing title to passed title
   drawingTitle.value = title;


### PR DESCRIPTION
Add anonymous crossorigin attribute back to s3 image that gets drawn on canvas to allow user to access and update image without credentials, as this was not the core of the issue; the issue was that the CORS header was not getting applied to S3 image sent from the back-end due to URL format (https://github.com/zeke/zeke.heroku.com/blob/master/source/_posts/2012-10-11-s3-cors-canvas.markdown) -- see estherh5/api.crystalprism.io@638c292 for more details