### PR TITLE
Fix drawing function to take user to correct URL

### DIFF
--- a/user/my-account/main.js
+++ b/user/my-account/main.js
@@ -797,8 +797,8 @@ function displayDrawings(type, drawings) {
 
     // Go to easel page for drawing if user clicks drawing
     drawing.onclick = function() {
-      window.location = '../../canvashare/easel/?drawing=' + drawing
-        .dataset.drawing;
+      window.location = '../../canvashare/easel/?drawing=' + this.dataset
+        .drawing;
       return;
     }
 


### PR DESCRIPTION
Fix drawing click function by replacing 'drawing' variable with 'this' to ensure the clicked drawing takes the user to the easel page for the clicked drawing instead of for the 'drawing' variable