### PR TITLE
Fix drawing URL load

### DIFF
--- a/canvashare/easel/main.js
+++ b/canvashare/easel/main.js
@@ -156,7 +156,7 @@ function assembleEasel(drawingSrc, title) {
   drawingTitle.value = title;
 
   // Set drawing source to passed drawing source
-  initialDrawing.src = drawingSrc;
+  initialDrawing.src = drawingSrc + '?=' + new Date().getTime();
 
   // Add initial drawing to HTML canvas
   canvasContext = document.getElementById('canvas').getContext('2d');


### PR DESCRIPTION
Update drawing URL that loads on easel page by adding a string to the end of the URL to prevent browser caching (which prevents the image from loading due to CORS restrictions)