### PR TITLE
CanvaShare Easel Cursor Fix [0.2.10]

### DIFF
--- a/canvashare/easel/index.html
+++ b/canvashare/easel/index.html
@@ -100,10 +100,8 @@
     <!-- Snap.svg script -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/snap.svg/0.4.1/snap.svg-min.js"></script>
 
-    <!-- canvg scripts -->
-    <script type="text/javascript" src="https://canvg.github.io/canvg/rgbcolor.js"></script>
-    <script type="text/javascript" src="https://canvg.github.io/canvg/StackBlur.js"></script>
-    <script type="text/javascript" src="https://canvg.github.io/canvg/canvg.js"></script>
+    <!-- canvg script -->
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/canvg/dist/browser/canvg.min.js"></script>
 
     <!-- Main and common JS scripts -->
     <script src="../../common.js"></script>


### PR DESCRIPTION
- Update reference to canvg script because canvg GitHub reference is outdated
- Remove additional scripts because they are for features that were never used in CanvaShare